### PR TITLE
added a workaround for commands under windows

### DIFF
--- a/lua/config/init.lua
+++ b/lua/config/init.lua
@@ -1,3 +1,7 @@
+-- on Windows in git-bash, the commands cannot be executed with :!<cmd>.
+-- to work around this, change the flag that is used to send commands
+vim.cmd("set shellcmdflag=-c")
+
 -- load the remap.lua file in the nvim/lua/config folder (i.e. search from the root, not from "here" locally)
 require("config.remap")
 

--- a/lua/config/init.lua
+++ b/lua/config/init.lua
@@ -1,6 +1,13 @@
+-- figure out on which OS this config is used
+function GetOS()
+    return package.config:sub(1,1) == "\\" and "Windows" or "Unix"
+end
+
 -- on Windows in git-bash, the commands cannot be executed with :!<cmd>.
 -- to work around this, change the flag that is used to send commands
-vim.cmd("set shellcmdflag=-c")
+if GetOS() == "Windows" then
+    vim.cmd("set shellcmdflag=-c")
+end
 
 -- load the remap.lua file in the nvim/lua/config folder (i.e. search from the root, not from "here" locally)
 require("config.remap")


### PR DESCRIPTION
set the shell flag to -c, which enables calling commands with :! in git-bash on windows