### PR TITLE
removed vim-sleuth because it was not handling tab widths as expected

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -34,6 +34,5 @@
   "toggle-lsp-diagnostics.nvim": { "branch": "main", "commit": "afcacba44d86df4c3c9752b869e78eb838f55765" },
   "toggleterm.nvim": { "branch": "main", "commit": "066cccf48a43553a80a210eb3be89a15d789d6e6" },
   "vim-glsl": { "branch": "master", "commit": "40dd0b143ef93f3930a8a409f60c1bb85e28b727" },
-  "vim-sleuth": { "branch": "master", "commit": "1cc4557420f215d02c4d2645a748a816c220e99b" },
   "which-key.nvim": { "branch": "main", "commit": "0099511294f16b81c696004fa6a403b0ae61f7a0" }
 }

--- a/lua/plugins/sleuth.lua
+++ b/lua/plugins/sleuth.lua
@@ -1,4 +1,0 @@
-return
-{
-    'tpope/vim-sleuth',
-}


### PR DESCRIPTION
- removed vim-sleuth, always default to 4 chars of tab width
- sessions may have stored tabwidths of 8. 
    - use `:set tabstop=4`, `:set shiftwidth=4`, `:SessionSave` to fix this