### PR TITLE
fix outline shortcut. was Ctrl+O, which is "jump back", is "Ctrl+s"

### DIFF
--- a/lua/plugins/outline.lua
+++ b/lua/plugins/outline.lua
@@ -6,7 +6,7 @@ return {
     lazy = true,
     cmd = { "Outline", "OutlineOpen" },
     keys = {
-        { "<C-o>", "<cmd>Outline<CR>", desc = "Toggle Outline" },
+        { "<C-s>", "<cmd>Outline<CR>", desc = "Toggle Outline (\"Solution Explorer\")" },
     },
     opts = {
         -- any custom opts


### PR DESCRIPTION
putting outline on Ctrl+O broke the "jump back" shortcut. instead it is now put onto Ctrl+S, which is (hopefully) not used elswehere. Think of it as "Solution Explorer" as in Visual Studio.